### PR TITLE
Add feature to create folder if not exists

### DIFF
--- a/http-server-upload.js
+++ b/http-server-upload.js
@@ -186,7 +186,7 @@ server.on('request', (req, res) => {
         fields.path = '';
       }
 
-      targetPath = path.join(uploadDir, fields.path);
+      let targetPath = path.join(uploadDir, fields.path);
       fs.stat(targetPath, (err) => {
         if (err) {
           console.log(`Target path ${targetPath} does not exist, trying to create it...`);

--- a/http-server-upload.js
+++ b/http-server-upload.js
@@ -186,11 +186,18 @@ server.on('request', (req, res) => {
         fields.path = '';
       }
 
-      fs.stat(path.join(uploadDir, fields.path), (err) => {
+      targetPath = path.join(uploadDir, fields.path);
+      fs.stat(targetPath, (err) => {
         if (err) {
-          res.write('Path does not exist!');
-          files.uploads.forEach((file) => file && fs.unlink(file.filepath));
-          return res.end();
+          console.log(`Target path ${targetPath} does not exist, trying to create it...`);
+          fs.mkdir(targetPath, (err) => {
+            if (err) {
+              console.log('Unable to create target path folder !');
+              res.write('Unable to create target path folder !');
+              files.uploads.forEach((file) => file && fs.unlink(file.filepath));
+              return res.end();
+            }
+          });
         }
 
         let count = 0;


### PR DESCRIPTION
When I try to upload a file specifiying a target path that does not exist on server, the request fails.
The server should create the folder, perhaps only if a property enables that feature (not covered by this PR at this time) ?