### PR TITLE
Move files to new folder in mkdirSync callback

### DIFF
--- a/http-server-upload.js
+++ b/http-server-upload.js
@@ -209,6 +209,19 @@ server.on('request', (req, res) => {
                 }));
                 return res.end();
               }
+
+              let count = 0;
+              files.uploads.forEach((file) => {
+                if (!file) return;
+                const newPath = path.join(uploadDir, fields.path, file.originalFilename);
+                fs.renameSync(file.filepath, newPath);
+                console.log(new Date().toUTCString(), '- File uploaded', newPath);
+                count++;
+              });
+      
+              res.write(count > 1 ? `${count} files uploaded!` : 'File uploaded!');
+              return res.end();
+
             });
           } else {
             res.write('Path does not exist!');


### PR DESCRIPTION
Definitely sorry but previous version don't work : we need to move uploaded files to the newly created folder in `fs.mkdirSync` callback to be sure that folder exists.
This race condition was difficult to test : I never got an error executing test script locally and it only appeared in a Docker/Openshift environment (http-server-upload embedded in a Docker image and configured to upload files on an Openshift PVC) but this time I tested and validated my fix on target environment.